### PR TITLE
added windows howto and fix file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,30 @@ How to use?
 
 3. cd repo directory.
 
-4. python -m pip install -r requirments.txt OR use virtualenv.
+4. python -m pip install -r requires.txt OR use virtualenv.
 
 5. make html
 
 6. my_browser build/html/index.html
+
+Windows users:
+========================
+
+1. Install python https://www.python.org/downloads/release/python-378/
+
+2. git clone this_repo
+
+3. cd repo directory
+
+4. python -m pip install -r requires.txt
+
+5. install make tools https://sourceforge.net/projects/gnuwin32/files/make/3.81/make-3.81.exe/download  - download, run, install
+
+6. add make.exe into %PATH% variable ( in default install on 64bit machine you'll need to add C:\Program Files (x86)\GnuWin32\bin folder to %PATH% )
+
+7. run make html in repo_directory
+
+8. my_browser build/html/index.html
 
 
 reStructuredText syntax (russian)


### PR DESCRIPTION
Windows users how to add.
Fix description about filename requirments.txt (it's named requires.txt)